### PR TITLE
Fix to use previous value for parameters

### DIFF
--- a/lib/createChangeSet.js
+++ b/lib/createChangeSet.js
@@ -3,6 +3,7 @@
 const _ = require('lodash')
 
 const createChangeSet = (plugin, stackName, changeSetName, changeSetType) => {
+  const compiledTemplate = plugin.serverless.service.provider.compiledCloudFormationTemplate || {}
   const compiledTemplateFileName = 'compiled-cloudformation-template.json'
   const templateUrl = `https://s3.amazonaws.com/${plugin.bucketName}/${plugin.serverless.service.package.artifactDirectoryName}/${compiledTemplateFileName}`
 
@@ -22,7 +23,10 @@ const createChangeSet = (plugin, stackName, changeSetName, changeSetType) => {
       'CAPABILITY_NAMED_IAM'
     ],
     ChangeSetType: changeSetType,
-    Parameters: [],
+    Parameters: Object.keys(compiledTemplate.Parameters || {}).map(key => ({
+      ParameterKey: key,
+      UsePreviousValue: true
+    })),
     TemplateURL: templateUrl,
     Tags: Object.keys(stackTags).map((key) => ({
       Key: key,

--- a/lib/createChangeSet.test.js
+++ b/lib/createChangeSet.test.js
@@ -133,5 +133,22 @@ describe('updateStack', () => {
           )
         })
     })
+
+    it('should use previous value for parameters', () => {
+      serverlessChangeSets.serverless.service.provider.compiledCloudFormationTemplate = {
+        Parameters: {
+          param1: {},
+          param2: {}
+        }
+      }
+
+      return createChangeSet.bind(serverlessChangeSets)().then(() => {
+        expect(createChangeSetStub.args[0][2].Parameters)
+          .to.deep.equal([
+            { ParameterKey: 'param1', UsePreviousValue: true },
+            { ParameterKey: 'param2', UsePreviousValue: true }
+          ])
+      })
+    })
   })
 })


### PR DESCRIPTION
Currently when `Parameters` are defined in the template this plugin fails because the parameters must also be defined in any changesets. This is a fix that adds the parameters to the changeset and tells Cloudformation to use the previous value which seems like a reasonable way to handle this.