### PR TITLE
Look for stage on both options and provider  & skip execution when there are no changes

### DIFF
--- a/lib/createChangeSet.js
+++ b/lib/createChangeSet.js
@@ -2,12 +2,12 @@
 
 const _ = require('lodash')
 
-const createChangeSet = (plugin, stackName, changeSetName, changeSetType) => {
+const createChangeSet = (plugin, stackName, stage, changeSetName, changeSetType) => {
   const compiledTemplateFileName = 'compiled-cloudformation-template.json'
   const templateUrl = `https://s3.amazonaws.com/${plugin.bucketName}/${plugin.serverless.service.package.artifactDirectoryName}/${compiledTemplateFileName}`
 
   let stackTags = {
-    STAGE: plugin.options.stage
+    STAGE: stage
   }
   // Merge additional stack tags
   if (typeof plugin.serverless.service.provider.stackTags === 'object') {
@@ -39,22 +39,27 @@ const createChangeSet = (plugin, stackName, changeSetName, changeSetType) => {
       'CloudFormation',
       'createChangeSet',
       params,
-      plugin.options.stage,
+      stage,
       plugin.options.region
     )
 }
 
 module.exports = {
   createChangeSet () {
+    if (this.shouldNotDeploy) {
+      return Promise.resolve()
+    }
+
     const stackName = this.provider.naming.getStackName()
+    const stage = this.options.stage || this.serverless.service.provider.stage
     const changeSetName = this.options.changeSetName ? this.options.changeSetName : `${stackName}-${Date.now()}`
 
     this.serverless.cli.log(`Creating CloudFormation ChangeSet [${changeSetName}]...`)
-    return createChangeSet(this, stackName, changeSetName, 'UPDATE')
+    return createChangeSet(this, stackName, stage, changeSetName, 'UPDATE')
       .catch(e => {
         if (e.message.indexOf('does not exist') > -1) {
           this.serverless.cli.log(`Stack [${stackName}] does not exist. Creating a new empty stack...`)
-          return createChangeSet(this, stackName, changeSetName, 'CREATE')
+          return createChangeSet(this, stackName, stage, changeSetName, 'CREATE')
         }
         throw e
       })

--- a/lib/createChangeSet.test.js
+++ b/lib/createChangeSet.test.js
@@ -7,24 +7,23 @@ const Serverless = require('serverless/lib/Serverless')
 const ServerlessCloudFormationChangeSets = require('../index')
 const sinon = require('sinon')
 
+function buildServerlessChangeSets (options = { stage: 'dev', region: 'us-east-1', changeset: 'test'}) {
+  const serverless = new Serverless()
+  serverless.config.servicePath = 'foo'
+  serverless.setProvider('aws', new AwsProvider(serverless))
+  const serverlessChangeSets = new ServerlessCloudFormationChangeSets(serverless, options)
+  serverless.service.service = `service-${(new Date()).getTime().toString()}`
+  serverlessChangeSets.bucketName = 'deployment-bucket'
+  serverlessChangeSets.serverless.service.package.artifactDirectoryName = 'somedir'
+  serverlessChangeSets.serverless.cli = new serverless.classes.CLI()
+  return serverlessChangeSets
+}
+
 describe('updateStack', () => {
-  let serverless
   let serverlessChangeSets
 
   beforeEach(() => {
-    serverless = new Serverless()
-    serverless.config.servicePath = 'foo'
-    serverless.setProvider('aws', new AwsProvider(serverless))
-    const options = {
-      stage: 'dev',
-      region: 'us-east-1',
-      changeset: 'test'
-    }
-    serverlessChangeSets = new ServerlessCloudFormationChangeSets(serverless, options)
-    serverless.service.service = `service-${(new Date()).getTime().toString()}`
-    serverlessChangeSets.bucketName = 'deployment-bucket'
-    serverlessChangeSets.serverless.service.package.artifactDirectoryName = 'somedir'
-    serverlessChangeSets.serverless.cli = new serverless.classes.CLI()
+    serverlessChangeSets = buildServerlessChangeSets()
   })
 
   describe('#createChangeSet()', () => {
@@ -132,6 +131,27 @@ describe('updateStack', () => {
             'us-east-1'
           )
         })
+    })
+
+    it('should skip execution when there are no changes', () => {
+      serverlessChangeSets.shouldNotDeploy = true
+      return createChangeSet.bind(serverlessChangeSets)()
+        .then(() => {
+          sinon.assert.notCalled(createChangeSetStub)
+        })
+    })
+
+    it('should use provider stage when not available in the options', () => {
+      serverlessChangeSets = buildServerlessChangeSets({ region: 'us-east-1', changeset: 'test'})
+      createChangeSetStub = sinon.stub(serverlessChangeSets.provider, 'request').resolves()
+      serverlessChangeSets.serverless.service.provider.stage = 'test1'
+
+      return createChangeSet.bind(serverlessChangeSets)().then(() => {
+        expect(createChangeSetStub.args[0][2].Tags)
+          .to.deep.equal([
+            { Key: 'STAGE', Value: 'test1' }
+          ])
+      })
     })
   })
 })


### PR DESCRIPTION
This PR addresses the following issues:

## Look for the stage in the options and provider objects

Currently if no stage is informed as option the deployment fails with:

```
Serverless Error ---------------------------------------
 
  Missing required key 'Value' in params.Tags[0]
```

I added a logic to look for the stage on the provider object when it is not available on the options.

## Plugin throws an error message when there are no changes to deploy

Currently when there are no changes to deploy the plugin throws (described on  #9 ):

```
Serverless: Packaging service...
Serverless: Service files not changed. Skipping deployment...
Serverless: Creating CloudFormation ChangeSet [...]...

  Serverless Error ---------------------------------------

  S3 error: Unable to get the object https://s3.amazonaws.com/...
```

I added a logic to check `this.shouldNotDeploy` variable before doing anything. This way the plugin skips the creation of the changeset when  there are no changes.