### PR TITLE
fixed failure when default stage is used

### DIFF
--- a/lib/createChangeSet.js
+++ b/lib/createChangeSet.js
@@ -7,7 +7,7 @@ const createChangeSet = (plugin, stackName, changeSetName, changeSetType) => {
   const templateUrl = `https://s3.amazonaws.com/${plugin.bucketName}/${plugin.serverless.service.package.artifactDirectoryName}/${compiledTemplateFileName}`
 
   let stackTags = {
-    STAGE: plugin.options.stage
+    STAGE: plugin.provider.getStage()
   }
   // Merge additional stack tags
   if (typeof plugin.serverless.service.provider.stackTags === 'object') {


### PR DESCRIPTION
If the user doesn't pass the stage as a parameter then the AWS provider uses the default stage, i.e. "dev". When this is the case this plugin fails with the error below because the stage parameter is undefined in the plugin.options object. 

The proposed change just reads the stage from the AWS provider function which always returns a valid stage.

`Serverless: Creating CloudFormation ChangeSet [aws-sls-dev-1582896674278]...

 Serverless Error ---------------------------------------

Missing required key 'Value' in params.Tags[0]`
